### PR TITLE
Merge Master into release_1_0

### DIFF
--- a/schemas/versions_GET.json
+++ b/schemas/versions_GET.json
@@ -25,7 +25,7 @@
                     "api_base_url": {
                         "type": "string",
                         "required": false
-                    },
+                    }
                 }
             }
         }


### PR DESCRIPTION
There was a typo fix applied to `master` but not to `release_1_0`